### PR TITLE
chore: bump rlg-cli and rlg-mcp to 0.0.9 (lockstep workspace versions)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-cli"
-version = "0.0.1"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1353,7 +1353,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-mcp"
-version = "0.0.1"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "rlg",

--- a/crates/rlg-cli/Cargo.toml
+++ b/crates/rlg-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-cli"
-version = "0.0.1"
+version = "0.0.9"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/rlg-cli/README.md
+++ b/crates/rlg-cli/README.md
@@ -59,7 +59,7 @@ rlg /var/log/app.ndjson \
 
 ### Input
 
-For `0.0.1`, the CLI accepts the **canonical `LogFormat::JSON`
+For `0.0.9`, the CLI accepts the **canonical `LogFormat::JSON`
 shape** — one record per line. Unparseable lines pass through
 verbatim so you can pipe non-rlg log noise through `rlg`
 without losing entries.

--- a/crates/rlg-mcp/Cargo.toml
+++ b/crates/rlg-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-mcp"
-version = "0.0.1"
+version = "0.0.9"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -35,7 +35,7 @@ path = "src/main.rs"
 
 [dependencies]
 rlg = { version = "0.0.9", path = "../rlg" }
-rlg-cli = { version = "0.0.1", path = "../rlg-cli" }
+rlg-cli = { version = "0.0.9", path = "../rlg-cli" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"

--- a/crates/rlg-mcp/README.md
+++ b/crates/rlg-mcp/README.md
@@ -79,7 +79,7 @@ the executable and no arguments.
 
 ## Limitations
 
-- v0.0.1 only parses the canonical `LogFormat::JSON` input
+- v0.0.9 only parses the canonical `LogFormat::JSON` input
   shape. MCP / OTLP / ECS / GELF transport-envelope parsing
   is tracked under
   [`crates/rlg-cli/doc/INPUT-FORMATS.md`](../rlg-cli/doc/INPUT-FORMATS.md)

--- a/crates/rlg/src/logger.rs
+++ b/crates/rlg/src/logger.rs
@@ -166,9 +166,15 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(engine_filter)]
     fn test_rlg_logger_enabled() {
+        // ENGINE.filter_level is process-wide state; serialise with
+        // tests that mutate it (below) to prevent test-ordering races
+        // under tarpaulin's threading.
+        let prior = ENGINE.filter_level();
+        ENGINE.set_filter(LogLevel::ALL.to_numeric());
+
         let logger = RlgLogger::new(LogFormat::JSON);
-        // Default filter is 0 (ALL), so everything is enabled
         let metadata = log::MetadataBuilder::new()
             .level(log::Level::Trace)
             .build();
@@ -178,10 +184,13 @@ mod tests {
             .level(log::Level::Error)
             .build();
         assert!(log::Log::enabled(&logger, &metadata));
+
+        ENGINE.set_filter(prior);
     }
 
     #[test]
     #[cfg_attr(miri, ignore)]
+    #[serial_test::serial(engine_filter)]
     fn test_rlg_logger_log_below_filter_short_circuits() {
         // Raise the global filter so that Info records are rejected,
         // forcing the `!self.enabled(...)` early return.


### PR DESCRIPTION
The `v0.0.9` tag push failed at `release.yml`'s `validate` step because the companion crates shipped at `0.0.1` while the tag is `v0.0.9`. The workflow requires lockstep versions across the workspace (the noyalib pattern).

Bumps:
- `crates/rlg-cli/Cargo.toml`: `version = 0.0.9`
- `crates/rlg-mcp/Cargo.toml`: `version = 0.0.9` (and its path-dep on `rlg-cli` to match)
- README references to v0.0.1 → v0.0.9
- `Cargo.lock` refreshed

Once merged, I'll force-update the `v0.0.9` tag to the new merge commit (nothing was published yet, so this is safe). The new tag push will trigger the full publish pipeline cleanly.