### PR TITLE
chore(deps): apply dependabot bumps (closes #146, #147)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
           persist-credentials: false
 
       - name: Create release with auto-generated notes
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           generate_release_notes: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.7",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -67,6 +82,15 @@ name = "anstyle-parse"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -257,9 +281,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -267,11 +291,11 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -279,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -500,7 +524,7 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
 dependencies = [
- "anstream",
+ "anstream 0.6.21",
  "anstyle",
  "env_filter",
  "jiff",
@@ -897,9 +921,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "memchr"
@@ -1498,9 +1522,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -1718,9 +1742,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "pin-project-lite",
@@ -1729,9 +1753,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/rlg-cli/Cargo.toml
+++ b/crates/rlg-cli/Cargo.toml
@@ -34,7 +34,7 @@ path = "src/main.rs"
 
 [dependencies]
 rlg = { version = "0.0.9", path = "../rlg" }
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
 

--- a/crates/rlg/Cargo.toml
+++ b/crates/rlg/Cargo.toml
@@ -74,17 +74,17 @@ envy = "0.4.2"
 euxis-commons = { version = "0.0.2", default-features = false, features = ["error", "config", "validation", "retry", "id", "time", "env"], package = "euxis-commons" }
 hostname = "0.4.2"
 itoa = "1.0.18"
-log = "0.4.29"
+log = "0.4.30"
 miette = { version = "7.5.0", features = ["fancy"], optional = true }
 notify = { version = "8.2.0", optional = true }
 parking_lot = "0.12.5"
 regex = "1.12.3"
 ryu = "1.0.23"
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+serde_json = "1.0.150"
 terminal_size = { version = "0.4", optional = true }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", default-features = false, features = ["fs", "io-util", "macros", "rt-multi-thread", "sync", "time"], optional = true }
+tokio = { version = "1.52.3", default-features = false, features = ["fs", "io-util", "macros", "rt-multi-thread", "sync", "time"], optional = true }
 toml = "1.0.7"
 tracing-core = "0.1.36"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["registry"], optional = true }
@@ -97,7 +97,7 @@ criterion = "0.8.2"
 env_logger = "0.11"
 serial_test = "3"
 tempfile = "3.27.0"
-tokio = { version = "1.50.0", default-features = false, features = ["fs", "io-util", "macros", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.52.3", default-features = false, features = ["fs", "io-util", "macros", "rt-multi-thread", "sync", "time"] }
 tokio-test = "0.4.5"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3", features = ["fmt"] }

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 
 [lints.rust]
 missing_docs = "warn"


### PR DESCRIPTION
Consolidates the two open dependabot PRs (#146 + #147) into a single signed commit so the bumps land together and CI runs once.

## Cargo crates (was #147 — minor-and-patch group)

| Crate | From | To | Notes |
| --- | --- | --- | --- |
| `log` | 0.4.29 | 0.4.30 | New `std::net` capture support; MSRV bumped to 1.71 |
| `serde_json` | 1.0.149 | 1.0.150 | Bug fixes |
| `terminal_size` | 0.4.3 | 0.4.4 | Constraint already accepts; lock-only |
| `tokio` | 1.50.0 | 1.52.3 | tokio-macros 2.7.0 transitive |
| `env_logger` | 0.11.9 | 0.11.10 | Constraint already accepts; lock-only |
| `clap` | 4.5.60 | 4.6.1 | New transitives: anstream, anstyle-parse |

## GitHub Actions (was #146)

- `softprops/action-gh-release@v2` → `@v3` in `.github/workflows/release.yml`
- v3 moves to the Node 24 runtime — GitHub-hosted runners already support it.

## Verification

- [x] `cargo clippy --workspace --all-features -- -D warnings` — clean
- [x] `cargo test --workspace --all-features` — 33 test groups, all pass
- [x] `cargo audit` — 0 advisories

Once merged, dependabot will auto-close #146 and #147.