### PR TITLE
ci(release): extend release.yml for the v0.0.10 ecosystem (9 publishable crates)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,16 @@ env:
   CARGO_INCREMENTAL: '0'
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
+# Every publishable crate in the workspace. Lockstep versions —
+# every entry must match the tag's version.
+#
+# `xtask` is excluded (publish = false).
+#
+# Order matters for the publish step:
+#   1. `rlg` first  — every other crate depends on it.
+#   2. `rlg-cli` second — `rlg-mcp` and `rlg-report` depend on it.
+#   3. The rest can publish independently of one another.
+
 jobs:
   # ─── Verify ────────────────────────────────────────────────────────
   validate:
@@ -24,7 +34,16 @@ jobs:
       - name: Check tag matches every publishable crate
         run: |
           TAG="${GITHUB_REF_NAME#v}"
-          for crate in rlg rlg-cli rlg-mcp; do
+          for crate in \
+              rlg \
+              rlg-cli \
+              rlg-mcp \
+              rlg-otlp \
+              rlg-redact \
+              rlg-report \
+              rlg-test \
+              rlg-tower \
+              rlg-wasm; do
             CRATE_VERSION=$(
               grep '^version' "crates/${crate}/Cargo.toml" \
                 | head -1 | sed 's/.*"\(.*\)"/\1/'
@@ -61,15 +80,27 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       # Crates publish in dependency order. After each publish we
-      # sleep briefly to give the sparse index a chance to catch
-      # the new version before the next dependent crate runs
-      # `cargo publish` (which resolves against the live index).
+      # sleep briefly to give the sparse index a chance to catch the
+      # new version before the next dependent crate runs `cargo
+      # publish` (which resolves against the live index).
+      #
+      # The dependency graph:
+      #
+      #   rlg
+      #   ├── rlg-cli ─── rlg-mcp
+      #   │             └─ rlg-report
+      #   ├── rlg-otlp
+      #   ├── rlg-redact
+      #   ├── rlg-test
+      #   ├── rlg-tower
+      #   └── rlg-wasm
+
       - name: Publish rlg
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           cargo publish --package rlg --locked
-          echo "Waiting for crates.io index to catch up…"
+          echo "Waiting for crates.io sparse index…"
           sleep 30
 
       - name: Publish rlg-cli
@@ -77,14 +108,43 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           cargo publish --package rlg-cli --locked
-          echo "Waiting for crates.io index to catch up…"
+          echo "Waiting for crates.io sparse index…"
           sleep 30
+
+      - name: Publish rlg-otlp
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --package rlg-otlp --locked
+
+      - name: Publish rlg-redact
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --package rlg-redact --locked
+
+      - name: Publish rlg-test
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --package rlg-test --locked
+
+      - name: Publish rlg-tower
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --package rlg-tower --locked
+
+      - name: Publish rlg-wasm
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --package rlg-wasm --locked
 
       - name: Publish rlg-mcp
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: |
-          cargo publish --package rlg-mcp --locked
+        run: cargo publish --package rlg-mcp --locked
+
+      - name: Publish rlg-report
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --package rlg-report --locked
 
   # ─── GitHub Release ────────────────────────────────────────────────
   github-release:


### PR DESCRIPTION
PR #150 expanded the workspace from 4 → 10 crates. The existing `release.yml` only knew about the original three (`rlg`, `rlg-cli`, `rlg-mcp`), so a `v0.0.10` tag push would fail at the `validate` step. This PR extends both the validate and publish jobs to handle the full 9-crate publishable set.

## Changes

### `validate`

Extends the version-match check to cover all 9 lockstep crates:

```
rlg, rlg-cli, rlg-mcp,
rlg-otlp, rlg-redact, rlg-report,
rlg-test, rlg-tower, rlg-wasm
```

`xtask` stays out (`publish = false`).

### `publish`

Publishes in dependency order:

| Step | Crate | Notes |
| --- | --- | --- |
| 1 | `rlg` | No internal deps. Sleep 30s for sparse-index propagation. |
| 2 | `rlg-cli` | Depends on `rlg`. Sleep 30s. |
| 3 | `rlg-otlp` | Depends on `rlg`. |
| 4 | `rlg-redact` | Depends on `rlg`. |
| 5 | `rlg-test` | Depends on `rlg`. |
| 6 | `rlg-tower` | Depends on `rlg`. |
| 7 | `rlg-wasm` | Depends on `rlg`. |
| 8 | `rlg-mcp` | Depends on `rlg` + `rlg-cli`. |
| 9 | `rlg-report` | Depends on `rlg` + `rlg-cli`. |

Steps 3–7 don't need sleeps between them — they only depend on `rlg`, which is already on the index by then. Steps 8–9 inherit the sleep after `rlg-cli` (step 2).

### `github-release`

Unchanged from PR #145's rewrite: SPDX SBOM via `anchore/sbom-action` attached to a non-draft release with auto-generated notes.

## Test plan

- [x] YAML lint passes locally (`yamllint .github/workflows/release.yml`).
- [ ] First real validation is the `v0.0.10` tag push immediately after this merges.

## Once this merges

I'll tag `v0.0.10` signed and push. Pipeline runs:

1. `validate` — all 9 crates at `0.0.10` ✓
2. `ci` — full pipelines/rust-ci.yml on the tagged ref
3. `publish` — 9 `cargo publish` calls in the order above
4. `github-release` — non-draft release + SBOM