### PR TITLE
docs(readme): reformat the Tools section as a bullet list

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ cargo install rlg-mcp       # the `rlg-mcp` MCP server
 cargo install rlg-report    # the `rlg-report` digest tool
 ```
 
+## Tools
+
+The MCP server crate, [`rlg-mcp`](crates/rlg-mcp/README.md), exposes rlg
+log streams to LLM agents as three MCP tools over the stdio transport:
+
+- `tail_log` — `path`, optional `n` (default 100) → last `n` parseable records, rendered in Logfmt.
+- `filter_log` — `path`, optional `min_level` / `component` / `format` → records matching every supplied filter, in the chosen `LogFormat`.
+- `summarize_errors` — `path` → JSON map of `component → error_count` for ERROR-and-above records.
+
 ## Workspace layout
 
 ```text

--- a/crates/rlg-mcp/README.md
+++ b/crates/rlg-mcp/README.md
@@ -31,11 +31,9 @@ Requires Rust **1.88.0** or newer (edition 2024).
 
 ## Tools
 
-| Tool | Inputs | Returns |
-| --- | --- | --- |
-| **`tail_log`** | `path`, optional `n` (default 100) | Last `n` parseable records, rendered in Logfmt. |
-| **`filter_log`** | `path`, optional `min_level`, `component`, `format` | Records matching every supplied filter, in the chosen `LogFormat`. |
-| **`summarize_errors`** | `path` | JSON map of `component → error_count` for ERROR-and-above records. |
+- `tail_log` — Inputs: `path`, optional `n` (default 100). Returns the last `n` parseable records, rendered in Logfmt.
+- `filter_log` — Inputs: `path`, optional `min_level`, `component`, `format`. Returns records matching every supplied filter, in the chosen `LogFormat`.
+- `summarize_errors` — Inputs: `path`. Returns a JSON map of `component → error_count` for ERROR-and-above records.
 
 ## Wire format
 


### PR DESCRIPTION
Directory crawlers (mcp.so and similar) auto-extract tools from a `## Tools` heading but parse bullets, not tables. Same entries, same wording, verified against the code. Mirrors camt053-mcp#75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)