### PR TITLE
fix(security): crossbeam-epoch RUSTSEC-2026-0204 + CI gate repairs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.19"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4279b0f31df31b4add8aeae57d40f3b5e53aad2b531e89b982bd75ed1898851d"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/rlg/src/engine.rs
+++ b/crates/rlg/src/engine.rs
@@ -142,7 +142,7 @@ impl LockFreeEngine {
                         }
                         for event in batch.iter().flatten() {
                             fmt_buf.clear();
-                            let _ = writeln!(fmt_buf, "{}", &event.log);
+                            let _ = writeln!(fmt_buf, "{}", event.log);
                             sink.emit(event.level.as_str(), &fmt_buf);
                         }
 

--- a/crates/rlg/src/log.rs
+++ b/crates/rlg/src/log.rs
@@ -331,7 +331,7 @@ impl Log {
         write!(
             f,
             "{} - - [{}] \"{}\" {} {}",
-            &*CACHED_HOSTNAME,
+            *CACHED_HOSTNAME,
             self.time,
             self.description,
             self.level,

--- a/crates/rlg/tests/test_coverage_gaps.rs
+++ b/crates/rlg/tests/test_coverage_gaps.rs
@@ -838,7 +838,7 @@ mod tests {
     // =========================================================================
 
     #[test]
-    #[cfg(not(windows))]
+    #[cfg(all(not(windows), feature = "tui"))]
     fn test_get_terminal_height_of_non_terminal() {
         // A regular file is not a terminal, so terminal_size_of returns None → fallback 24
         let file = std::fs::File::open("/dev/null").unwrap();
@@ -850,7 +850,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(windows))]
+    #[cfg(all(not(windows), feature = "tui"))]
     fn test_get_terminal_height_of_with_pty() {
         // Open a PTY master to get a real terminal fd
         let result = std::fs::OpenOptions::new()

--- a/crates/rlg/tests/test_coverage_v007.rs
+++ b/crates/rlg/tests/test_coverage_v007.rs
@@ -179,7 +179,7 @@ mod tests {
 
     #[test]
     fn test_tui_get_terminal_height_of() {
-        #[cfg(not(windows))]
+        #[cfg(all(not(windows), feature = "tui"))]
         {
             // Test with a non-terminal handle (pipe)
             let (r, _w) =

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -188,7 +188,7 @@ version = "0.8.7"
 criteria = "safe-to-run"
 
 [[exemptions.crossbeam-epoch]]
-version = "0.9.19"
+version = "0.9.20"
 criteria = "safe-to-run"
 
 [[exemptions.crossbeam-queue]]


### PR DESCRIPTION
Fixes the pre-existing CI failures blocking the docs PR: crossbeam-epoch bumped past RUSTSEC-2026-0204, cargo-vet exemptions updated to match the lock, two new-Rust clippy errors fixed (useless_borrows_in_formatting), and three test cfg gates corrected to include feature = \"tui\". All local gates green (deny/vet/audit/clippy/tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)