### PR TITLE
feat(mcp): add prompts and resources for MCP Trinity parity

### DIFF
--- a/crates/rlg-mcp/src/lib.rs
+++ b/crates/rlg-mcp/src/lib.rs
@@ -204,7 +204,7 @@ pub fn dispatch(req: &Request) -> Option<Response> {
     let result = match req.method.as_str() {
         "initialize" => Ok(serde_json::json!({
             "protocolVersion": "2025-06-18",
-            "capabilities": { "tools": {} },
+            "capabilities": { "tools": {}, "prompts": {}, "resources": {} },
             "serverInfo": { "name": "rlg-mcp", "version": env!("CARGO_PKG_VERSION") }
         })),
         "tools/list" => Ok(serde_json::json!({
@@ -278,6 +278,11 @@ pub fn dispatch(req: &Request) -> Option<Response> {
             ]
         })),
         "tools/call" => dispatch_tool_call(&req.params),
+        "prompts/list" => Ok(prompts_list()),
+        "prompts/get" => prompts_get(&req.params),
+        "resources/list" => Ok(resources_list()),
+        "resources/templates/list" => Ok(resource_templates_list()),
+        "resources/read" => resources_read(&req.params),
         "notifications/initialized" | "notifications/cancelled" => {
             // MCP notifications — no response required.
             return None;
@@ -369,6 +374,167 @@ fn wrap_text(s: String) -> serde_json::Value {
 }
 
 // ---------------------------------------------------------------------------
+// Prompts.
+// ---------------------------------------------------------------------------
+
+/// Descriptors returned to MCP clients via `prompts/list`.
+fn prompts_list() -> serde_json::Value {
+    serde_json::json!({
+        "prompts": [
+            {
+                "name": "triage_error_spike",
+                "title": "Triage an rlg error spike",
+                "description": "Guided SRE workflow for investigating a spike \
+                    of errors in an rlg log using tail_log, filter_log and \
+                    summarize_errors.",
+                "arguments": [
+                    {
+                        "name": "path",
+                        "description": "Filesystem path to the rlg log file to triage.",
+                        "required": false
+                    },
+                    {
+                        "name": "window_minutes",
+                        "description": "Recent time window to focus on, in minutes.",
+                        "required": false
+                    }
+                ]
+            }
+        ]
+    })
+}
+
+/// `prompts/get` handler. Returns the prompt-message payload, or an
+/// error string (mapped to a JSON-RPC error envelope).
+fn prompts_get(
+    params: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let name = params
+        .get("name")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| "missing `name`".to_string())?;
+    match name {
+        "triage_error_spike" => Ok(triage_error_spike(params)),
+        other => Err(format!("unknown prompt: {other}")),
+    }
+}
+
+/// Build the `triage_error_spike` prompt messages, embedding the
+/// caller-supplied `path` and `window_minutes` arguments when present.
+fn triage_error_spike(params: &serde_json::Value) -> serde_json::Value {
+    let args = params.get("arguments").cloned().unwrap_or_default();
+    let path = args
+        .get("path")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+    let window = args
+        .get("window_minutes")
+        .and_then(serde_json::Value::as_u64);
+    let target = if path.is_empty() {
+        "the rlg log".to_string()
+    } else {
+        format!("`{path}`")
+    };
+    let window_clause = match window {
+        Some(m) => format!(" Focus on roughly the last {m} minutes."),
+        None => String::new(),
+    };
+    let text = format!(
+        "Help me triage an error spike in {target}.{window_clause} Start with \
+         summarize_errors to get the ERROR-and-above count per component and \
+         spot which component spiked. Then call filter_log with \
+         min_level=ERROR (and component set to the worst offender) to read the \
+         actual failing records, and tail_log for the surrounding recent \
+         context. From the messages, group the errors by likely root cause and \
+         propose the most probable trigger (a recent deploy, a dependency \
+         outage, a config change) with the evidence for each."
+    );
+    serde_json::json!({
+        "description": "Guided rlg error-spike SRE triage workflow.",
+        "messages": [
+            { "role": "user", "content": { "type": "text", "text": text } }
+        ]
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Resources.
+// ---------------------------------------------------------------------------
+
+/// Static resource descriptors returned via `resources/list`.
+fn resources_list() -> serde_json::Value {
+    serde_json::json!({
+        "resources": [
+            {
+                "uri": "rlg://log-levels",
+                "name": "log-levels",
+                "title": "rlg severity ladder",
+                "description": "The ordered rlg log levels, lowest to highest \
+                    severity, as accepted by filter_log's min_level.",
+                "mimeType": "application/json"
+            }
+        ]
+    })
+}
+
+/// Templated resource descriptors returned via
+/// `resources/templates/list`.
+fn resource_templates_list() -> serde_json::Value {
+    serde_json::json!({
+        "resourceTemplates": [
+            {
+                "uriTemplate": "rlg://tail/{path}",
+                "name": "tail",
+                "title": "Recent rlg log tail",
+                "description": "The last 100 parseable rlg records from the log \
+                    file at {path}, newest last, as a read-only resource.",
+                "mimeType": "text/plain"
+            }
+        ]
+    })
+}
+
+/// `resources/read` handler. Serves the static severity ladder and the
+/// templated `rlg://tail/{path}` log tail; errors on an unknown URI.
+fn resources_read(
+    params: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let uri = params
+        .get("uri")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| "missing `uri`".to_string())?;
+    if uri == "rlg://log-levels" {
+        let text = serde_json::json!([
+            "TRACE", "DEBUG", "VERBOSE", "INFO", "WARN", "ERROR",
+            "FATAL", "CRITICAL"
+        ])
+        .to_string();
+        return Ok(resource_contents(uri, "application/json", text));
+    }
+    if let Some(path) = uri.strip_prefix("rlg://tail/") {
+        let lines = tail_log(std::path::Path::new(path), 100)
+            .map_err(|e| e.to_string())?;
+        return Ok(resource_contents(
+            uri,
+            "text/plain",
+            lines.join("\n"),
+        ));
+    }
+    Err(format!("resource not found: {uri}"))
+}
+
+/// Wrap resource text into the MCP `resources/read` reply shape.
+fn resource_contents(
+    uri: &str,
+    mime: &str,
+    text: String,
+) -> serde_json::Value {
+    serde_json::json!({
+        "contents": [ { "uri": uri, "mimeType": mime, "text": text } ]
+    })
+}
+
+// ---------------------------------------------------------------------------
 // Tests.
 // ---------------------------------------------------------------------------
 
@@ -436,6 +602,138 @@ mod tests {
         let result = r.result.unwrap();
         assert_eq!(result["protocolVersion"], "2025-06-18");
         assert_eq!(result["serverInfo"]["name"], "rlg-mcp");
+        assert!(result["capabilities"]["prompts"].is_object());
+        assert!(result["capabilities"]["resources"].is_object());
+    }
+
+    #[test]
+    fn dispatch_prompts_list_returns_the_prompt() {
+        let r = dispatch(&req("prompts/list", serde_json::json!({})))
+            .expect("response");
+        let prompts = r.result.unwrap();
+        let names: Vec<&str> = prompts["prompts"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|p| p["name"].as_str().unwrap())
+            .collect();
+        assert!(names.contains(&"triage_error_spike"));
+    }
+
+    #[test]
+    fn dispatch_prompts_get_embeds_arguments() {
+        let r = dispatch(&req(
+            "prompts/get",
+            serde_json::json!({
+                "name": "triage_error_spike",
+                "arguments": { "path": "/var/log/app.log", "window_minutes": 15 }
+            }),
+        ))
+        .expect("response");
+        let text = r.result.unwrap()["messages"][0]["content"]["text"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert!(text.contains("/var/log/app.log"));
+        assert!(text.contains("15 minutes"));
+        assert!(text.contains("summarize_errors"));
+    }
+
+    #[test]
+    fn dispatch_prompts_get_without_arguments_is_generic() {
+        let r = dispatch(&req(
+            "prompts/get",
+            serde_json::json!({ "name": "triage_error_spike" }),
+        ))
+        .expect("response");
+        let text = r.result.unwrap()["messages"][0]["content"]["text"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert!(text.contains("the rlg log"));
+    }
+
+    #[test]
+    fn dispatch_prompts_get_unknown_errors() {
+        let r = dispatch(&req(
+            "prompts/get",
+            serde_json::json!({ "name": "nope" }),
+        ))
+        .expect("response");
+        assert!(r.error.is_some());
+    }
+
+    #[test]
+    fn dispatch_prompts_get_missing_name_errors() {
+        let r = dispatch(&req("prompts/get", serde_json::json!({})))
+            .expect("response");
+        assert!(r.error.is_some());
+    }
+
+    #[test]
+    fn dispatch_resources_list_and_templates() {
+        let r = dispatch(&req("resources/list", serde_json::json!({})))
+            .expect("response");
+        assert_eq!(
+            r.result.unwrap()["resources"][0]["uri"],
+            "rlg://log-levels"
+        );
+        let t = dispatch(&req(
+            "resources/templates/list",
+            serde_json::json!({}),
+        ))
+        .expect("response");
+        assert_eq!(
+            t.result.unwrap()["resourceTemplates"][0]["uriTemplate"],
+            "rlg://tail/{path}"
+        );
+    }
+
+    #[test]
+    fn dispatch_resources_read_log_levels() {
+        let r = dispatch(&req(
+            "resources/read",
+            serde_json::json!({ "uri": "rlg://log-levels" }),
+        ))
+        .expect("response");
+        let text = r.result.unwrap()["contents"][0]["text"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert!(text.contains("ERROR"));
+    }
+
+    #[test]
+    fn dispatch_resources_read_tail_template() {
+        let f = write_log(&format!("{INFO}\n{ERROR}\n"));
+        let uri = format!("rlg://tail/{}", f.path().to_str().unwrap());
+        let r = dispatch(&req(
+            "resources/read",
+            serde_json::json!({ "uri": uri }),
+        ))
+        .expect("response");
+        let text = r.result.unwrap()["contents"][0]["text"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert!(text.contains("boom"));
+    }
+
+    #[test]
+    fn dispatch_resources_read_unknown_uri_errors() {
+        let r = dispatch(&req(
+            "resources/read",
+            serde_json::json!({ "uri": "rlg://mystery" }),
+        ))
+        .expect("response");
+        assert!(r.error.is_some());
+    }
+
+    #[test]
+    fn dispatch_resources_read_missing_uri_errors() {
+        let r = dispatch(&req("resources/read", serde_json::json!({})))
+            .expect("response");
+        assert!(r.error.is_some());
     }
 
     #[test]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -22,6 +22,9 @@ audit-as-crates-io = false
 [policy.rlg-cli]
 audit-as-crates-io = false
 
+[policy.rlg-ebpf]
+audit-as-crates-io = false
+
 [policy.rlg-mcp]
 audit-as-crates-io = false
 
@@ -76,7 +79,7 @@ version = "3.0.11"
 criteria = "safe-to-deploy"
 
 [[exemptions.anyhow]]
-version = "1.0.103"
+version = "1.0.104"
 criteria = "safe-to-deploy"
 
 [[exemptions.assert_cmd]]
@@ -128,15 +131,15 @@ version = "0.10.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap]]
-version = "4.6.1"
+version = "4.6.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_builder]]
-version = "4.6.0"
+version = "4.6.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_derive]]
-version = "4.6.1"
+version = "4.6.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_lex]]
@@ -185,10 +188,6 @@ criteria = "safe-to-run"
 
 [[exemptions.crossbeam-deque]]
 version = "0.8.7"
-criteria = "safe-to-run"
-
-[[exemptions.crossbeam-epoch]]
-version = "0.9.20"
 criteria = "safe-to-run"
 
 [[exemptions.crossbeam-queue]]
@@ -332,7 +331,7 @@ version = "1.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.http-body-util]]
-version = "0.1.3"
+version = "0.1.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.httparse]]
@@ -456,7 +455,7 @@ version = "1.1.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.libc]]
-version = "0.2.186"
+version = "0.2.189"
 criteria = "safe-to-deploy"
 
 [[exemptions.linux-raw-sys]]
@@ -676,11 +675,11 @@ version = "0.5.18"
 criteria = "safe-to-deploy"
 
 [[exemptions.regex]]
-version = "1.12.4"
+version = "1.13.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.regex-automata]]
-version = "0.4.14"
+version = "0.4.16"
 criteria = "safe-to-deploy"
 
 [[exemptions.regex-syntax]]
@@ -693,42 +692,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.ring]]
 version = "0.17.14"
-criteria = "safe-to-deploy"
-
-[[exemptions.rlg]]
-version = "0.0.11"
-criteria = "safe-to-deploy"
-
-[[exemptions.rlg-cli]]
-version = "0.0.11"
-criteria = "safe-to-deploy"
-
-[[exemptions.rlg-mcp]]
-version = "0.0.11"
-criteria = "safe-to-deploy"
-
-[[exemptions.rlg-otlp]]
-version = "0.0.11"
-criteria = "safe-to-deploy"
-
-[[exemptions.rlg-redact]]
-version = "0.0.11"
-criteria = "safe-to-deploy"
-
-[[exemptions.rlg-report]]
-version = "0.0.11"
-criteria = "safe-to-deploy"
-
-[[exemptions.rlg-test]]
-version = "0.0.11"
-criteria = "safe-to-deploy"
-
-[[exemptions.rlg-tower]]
-version = "0.0.11"
-criteria = "safe-to-deploy"
-
-[[exemptions.rlg-wasm]]
-version = "0.0.11"
 criteria = "safe-to-deploy"
 
 [[exemptions.ron]]
@@ -784,7 +747,7 @@ version = "1.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde]]
-version = "1.0.228"
+version = "1.0.229"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde-untagged]]
@@ -792,15 +755,15 @@ version = "0.1.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_core]]
-version = "1.0.228"
+version = "1.0.229"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_derive]]
-version = "1.0.228"
+version = "1.0.229"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_json]]
-version = "1.0.150"
+version = "1.0.151"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_spanned]]
@@ -816,11 +779,11 @@ version = "0.7.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.serial_test]]
-version = "3.5.0"
+version = "4.0.1"
 criteria = "safe-to-run"
 
 [[exemptions.serial_test_derive]]
-version = "3.5.0"
+version = "4.0.1"
 criteria = "safe-to-run"
 
 [[exemptions.shlex]]
@@ -859,6 +822,10 @@ criteria = "safe-to-deploy"
 version = "2.0.118"
 criteria = "safe-to-deploy"
 
+[[exemptions.syn]]
+version = "3.0.3"
+criteria = "safe-to-deploy"
+
 [[exemptions.sync_wrapper]]
 version = "1.0.2"
 criteria = "safe-to-deploy"
@@ -868,11 +835,11 @@ version = "0.4.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.thiserror]]
-version = "2.0.18"
+version = "2.0.19"
 criteria = "safe-to-deploy"
 
 [[exemptions.thiserror-impl]]
-version = "2.0.18"
+version = "2.0.19"
 criteria = "safe-to-deploy"
 
 [[exemptions.time]]
@@ -900,7 +867,7 @@ version = "1.11.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio]]
-version = "1.52.3"
+version = "1.53.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-macros]]
@@ -928,7 +895,7 @@ version = "0.8.23"
 criteria = "safe-to-deploy"
 
 [[exemptions.toml]]
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.toml_datetime]]
@@ -952,7 +919,7 @@ version = "0.1.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.toml_writer]]
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tonic]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -98,6 +98,18 @@ criteria = "safe-to-deploy"
 version = "1.1.2"
 notes = "Contains `unsafe` code but it's well-documented and scoped to what it's intended to be doing. Otherwise a well-focused and straightforward crate."
 
+[[audits.bytecode-alliance.audits.crossbeam-epoch]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.15 -> 0.9.18"
+notes = "Nontrivial update but mostly around dependencies and how `unsafe` code is managed. Everything looks the same shape as before."
+
+[[audits.bytecode-alliance.audits.crossbeam-epoch]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.18 -> 0.9.20"
+notes = "Minor updates, nothing out of place."
+
 [[audits.bytecode-alliance.audits.foldhash]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -384,6 +396,18 @@ aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust
 who = "Daniel Verkamp <dverkamp@chromium.org>"
 criteria = "safe-to-run"
 version = "0.2.2"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.crossbeam-epoch]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.9.14"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.crossbeam-epoch]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+delta = "0.9.14 -> 0.9.15"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
 [[audits.google.audits.difflib]]


### PR DESCRIPTION
## What

Adds MCP **prompts** and **resources** so this server exposes the full MCP
Trinity (tools + prompts + resources), matching the sibling servers that
already do (camt053-mcp, pain001-mcp).

## How

- New `@mcp.prompt` guidance prompt(s) teaching the recommended tool order.
- New `@mcp.resource` endpoint(s): static catalogue resources plus, where a
  per-id lookup exists, a templated URI resource. They reuse the functions the
  existing tools already call — no new domain logic.
- Rust servers gain `prompts/list`/`prompts/get` and
  `resources/list`/`resources/templates/list`/`resources/read` dispatch arms
  and advertise the capabilities in `initialize`.

## Verification

- MCP Inspector `prompts/list` and `resources/list` return non-empty arrays.
- Full test gate green: 100% coverage (Python), clippy `-D warnings` + fmt
  (Rust), plus ruff/black/mypy where configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)