### PR TITLE
feat(rlg-mcp): add tail_logs_glob multi-file glob log tailer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,6 +817,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
 name = "h2"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2081,6 +2087,7 @@ version = "0.0.12"
 dependencies = [
  "anyhow",
  "criterion",
+ "glob",
  "rlg",
  "rlg-cli",
  "serde",

--- a/crates/rlg-mcp/Cargo.toml
+++ b/crates/rlg-mcp/Cargo.toml
@@ -52,6 +52,7 @@ rlg-cli = { version = "0.0.12", path = "../rlg-cli" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
+glob = "0.3"
 
 [dev-dependencies]
 criterion = "0.8"

--- a/crates/rlg-mcp/src/lib.rs
+++ b/crates/rlg-mcp/src/lib.rs
@@ -101,6 +101,44 @@ pub fn summarize_errors(
     Ok(buckets)
 }
 
+/// Tail the last `n` records across every file matching a glob
+/// pattern (e.g. `/var/log/**/*.log`), newest last, optionally keeping
+/// only records at or above `level`. Matched files are read in sorted
+/// path order and their records concatenated before the final `n` are
+/// taken; unparseable lines are skipped.
+///
+/// # Errors
+/// Returns an error string if the glob pattern is invalid, or if a
+/// matched path cannot be read (e.g. it resolves to a directory).
+pub fn tail_logs_glob(
+    pattern: &str,
+    n: usize,
+    level: Option<LogLevel>,
+) -> Result<Vec<String>, String> {
+    let mut paths: Vec<std::path::PathBuf> = glob::glob(pattern)
+        .map_err(|e| format!("invalid glob pattern: {e}"))?
+        .filter_map(Result::ok)
+        .collect();
+    paths.sort();
+    let mut all = Vec::new();
+    for path in paths {
+        let content = std::fs::read_to_string(&path)
+            .map_err(|e| format!("read {}: {e}", path.display()))?;
+        for line in content.lines() {
+            if let Ok(record) = parse_record(line) {
+                if let Some(min) = level
+                    && record.level.to_numeric() < min.to_numeric()
+                {
+                    continue;
+                }
+                all.push(render(record, LogFormat::Logfmt));
+            }
+        }
+    }
+    let start = all.len().saturating_sub(n);
+    Ok(all.split_off(start))
+}
+
 // ---------------------------------------------------------------------------
 // JSON-RPC 2.0 transport (minimal subset of MCP).
 // ---------------------------------------------------------------------------
@@ -274,6 +312,27 @@ pub fn dispatch(req: &Request) -> Option<Response> {
                         },
                         "required": ["path"]
                     }
+                },
+                {
+                    "name": "tail_logs_glob",
+                    "title": "Tail rlg logs across a glob",
+                    "annotations": {
+                        "title": "Tail rlg logs across a glob",
+                        "readOnlyHint": true,
+                        "destructiveHint": false,
+                        "idempotentHint": true,
+                        "openWorldHint": true
+                    },
+                    "description": "Return the last N parseable rlg records across every file matching a glob pattern (e.g. `/var/log/**/*.log`), newest last, optionally filtered to a minimum level. Use this to tail many rotated or per-service log files at once; use `tail_log` for a single file and `summarize_errors` for per-component error totals.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "glob_pattern": { "type": "string", "description": "Glob pattern matching one or more rlg log files, e.g. `/var/log/**/*.log`." },
+                            "lines": { "type": "integer", "minimum": 1, "default": 100, "description": "How many of the most recent parseable records to return across all matched files (default 100)." },
+                            "level": { "type": "string", "enum": ["TRACE","DEBUG","VERBOSE","INFO","WARN","ERROR","FATAL","CRITICAL"], "description": "Keep only records at or above this severity. Omit to keep all levels." }
+                        },
+                        "required": ["glob_pattern"]
+                    }
                 }
             ]
         })),
@@ -309,6 +368,28 @@ fn dispatch_tool_call(
                 .unwrap_or(100) as usize;
             let lines =
                 tail_log(&path, n).map_err(|e| e.to_string())?;
+            Ok(wrap_text(lines.join("\n")))
+        }
+        "tail_logs_glob" => {
+            let pattern = args
+                .get("glob_pattern")
+                .and_then(serde_json::Value::as_str)
+                .ok_or_else(|| "missing `glob_pattern`".to_string())?;
+            let n = args
+                .get("lines")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(100) as usize;
+            let level = match args
+                .get("level")
+                .and_then(serde_json::Value::as_str)
+            {
+                Some(s) => Some(
+                    s.parse::<LogLevel>()
+                        .map_err(|e| format!("{e:?}"))?,
+                ),
+                None => None,
+            };
+            let lines = tail_logs_glob(pattern, n, level)?;
             Ok(wrap_text(lines.join("\n")))
         }
         "filter_log" => {
@@ -420,6 +501,117 @@ mod tests {
         assert_eq!(buckets.get("svc"), None);
     }
 
+    #[test]
+    fn tail_logs_glob_merges_matched_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.log"), format!("{INFO}\n"))
+            .unwrap();
+        std::fs::write(
+            dir.path().join("b.log"),
+            format!("{ERROR}\n{FATAL}\n"),
+        )
+        .unwrap();
+        let pattern = format!("{}/*.log", dir.path().to_str().unwrap());
+        let out = tail_logs_glob(&pattern, 100, None).unwrap();
+        assert_eq!(out.len(), 3);
+        let joined = out.join("\n");
+        assert!(joined.contains("hi"));
+        assert!(joined.contains("boom"));
+        assert!(joined.contains("down"));
+    }
+
+    #[test]
+    fn tail_logs_glob_filters_by_level() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("x.log"),
+            format!("{INFO}\n{ERROR}\n{FATAL}\n"),
+        )
+        .unwrap();
+        let pattern = format!("{}/*.log", dir.path().to_str().unwrap());
+        let out = tail_logs_glob(&pattern, 100, Some(LogLevel::ERROR))
+            .unwrap();
+        assert_eq!(out.len(), 2); // INFO dropped, ERROR + FATAL kept
+    }
+
+    #[test]
+    fn tail_logs_glob_respects_n() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("x.log"),
+            format!("{INFO}\n{ERROR}\n{FATAL}\n"),
+        )
+        .unwrap();
+        let pattern = format!("{}/*.log", dir.path().to_str().unwrap());
+        let out = tail_logs_glob(&pattern, 1, None).unwrap();
+        assert_eq!(out.len(), 1);
+        assert!(out[0].contains("down"));
+    }
+
+    #[test]
+    fn tail_logs_glob_rejects_bad_pattern() {
+        let err = tail_logs_glob("a/**b[", 10, None).unwrap_err();
+        assert!(err.contains("invalid glob pattern"));
+    }
+
+    #[test]
+    fn tail_logs_glob_reports_unreadable_match() {
+        // A pattern matching a directory: read_to_string fails on it.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("sub")).unwrap();
+        let pattern = format!("{}/sub", dir.path().to_str().unwrap());
+        let err = tail_logs_glob(&pattern, 10, None).unwrap_err();
+        assert!(err.contains("read"));
+    }
+
+    #[test]
+    fn dispatch_tail_logs_glob_via_tools_call() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.log"), format!("{ERROR}\n"))
+            .unwrap();
+        let pattern = format!("{}/*.log", dir.path().to_str().unwrap());
+        let r = dispatch(&req(
+            "tools/call",
+            serde_json::json!({
+                "name": "tail_logs_glob",
+                "arguments": { "glob_pattern": pattern, "level": "ERROR" }
+            }),
+        ))
+        .expect("response");
+        let text = r.result.unwrap()["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert!(text.contains("boom"));
+    }
+
+    #[test]
+    fn dispatch_tail_logs_glob_missing_pattern_errors() {
+        let r = dispatch(&req(
+            "tools/call",
+            serde_json::json!({ "name": "tail_logs_glob", "arguments": {} }),
+        ))
+        .expect("response");
+        assert!(r.error.is_some());
+    }
+
+    #[test]
+    fn dispatch_tail_logs_glob_bad_level_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.log"), format!("{INFO}\n"))
+            .unwrap();
+        let pattern = format!("{}/*.log", dir.path().to_str().unwrap());
+        let r = dispatch(&req(
+            "tools/call",
+            serde_json::json!({
+                "name": "tail_logs_glob",
+                "arguments": { "glob_pattern": pattern, "level": "NOPE" }
+            }),
+        ))
+        .expect("response");
+        assert!(r.error.is_some());
+    }
+
     fn req(method: &str, params: serde_json::Value) -> Request {
         Request {
             jsonrpc: "2.0".to_string(),
@@ -439,12 +631,15 @@ mod tests {
     }
 
     #[test]
-    fn dispatch_tools_list_returns_three_tools() {
+    fn dispatch_tools_list_returns_all_tools() {
         let r = dispatch(&req("tools/list", serde_json::json!({})))
             .expect("response");
-        let tools =
-            r.result.unwrap()["tools"].as_array().unwrap().len();
-        assert_eq!(tools, 3);
+        let result = r.result.unwrap();
+        let tools = result["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 4);
+        let names: Vec<&str> =
+            tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+        assert!(names.contains(&"tail_logs_glob"));
     }
 
     #[test]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -22,6 +22,9 @@ audit-as-crates-io = false
 [policy.rlg-cli]
 audit-as-crates-io = false
 
+[policy.rlg-ebpf]
+audit-as-crates-io = false
+
 [policy.rlg-mcp]
 audit-as-crates-io = false
 
@@ -76,7 +79,7 @@ version = "3.0.11"
 criteria = "safe-to-deploy"
 
 [[exemptions.anyhow]]
-version = "1.0.103"
+version = "1.0.104"
 criteria = "safe-to-deploy"
 
 [[exemptions.assert_cmd]]
@@ -128,15 +131,15 @@ version = "0.10.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap]]
-version = "4.6.1"
+version = "4.6.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_builder]]
-version = "4.6.0"
+version = "4.6.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_derive]]
-version = "4.6.1"
+version = "4.6.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_lex]]
@@ -185,10 +188,6 @@ criteria = "safe-to-run"
 
 [[exemptions.crossbeam-deque]]
 version = "0.8.7"
-criteria = "safe-to-run"
-
-[[exemptions.crossbeam-epoch]]
-version = "0.9.20"
 criteria = "safe-to-run"
 
 [[exemptions.crossbeam-queue]]
@@ -303,6 +302,10 @@ criteria = "safe-to-run"
 version = "0.4.3"
 criteria = "safe-to-deploy"
 
+[[exemptions.glob]]
+version = "0.3.4"
+criteria = "safe-to-deploy"
+
 [[exemptions.h2]]
 version = "0.4.15"
 criteria = "safe-to-deploy"
@@ -332,7 +335,7 @@ version = "1.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.http-body-util]]
-version = "0.1.3"
+version = "0.1.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.httparse]]
@@ -456,7 +459,7 @@ version = "1.1.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.libc]]
-version = "0.2.186"
+version = "0.2.189"
 criteria = "safe-to-deploy"
 
 [[exemptions.linux-raw-sys]]
@@ -676,11 +679,11 @@ version = "0.5.18"
 criteria = "safe-to-deploy"
 
 [[exemptions.regex]]
-version = "1.12.4"
+version = "1.13.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.regex-automata]]
-version = "0.4.14"
+version = "0.4.16"
 criteria = "safe-to-deploy"
 
 [[exemptions.regex-syntax]]
@@ -693,42 +696,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.ring]]
 version = "0.17.14"
-criteria = "safe-to-deploy"
-
-[[exemptions.rlg]]
-version = "0.0.11"
-criteria = "safe-to-deploy"
-
-[[exemptions.rlg-cli]]
-version = "0.0.11"
-criteria = "safe-to-deploy"
-
-[[exemptions.rlg-mcp]]
-version = "0.0.11"
-criteria = "safe-to-deploy"
-
-[[exemptions.rlg-otlp]]
-version = "0.0.11"
-criteria = "safe-to-deploy"
-
-[[exemptions.rlg-redact]]
-version = "0.0.11"
-criteria = "safe-to-deploy"
-
-[[exemptions.rlg-report]]
-version = "0.0.11"
-criteria = "safe-to-deploy"
-
-[[exemptions.rlg-test]]
-version = "0.0.11"
-criteria = "safe-to-deploy"
-
-[[exemptions.rlg-tower]]
-version = "0.0.11"
-criteria = "safe-to-deploy"
-
-[[exemptions.rlg-wasm]]
-version = "0.0.11"
 criteria = "safe-to-deploy"
 
 [[exemptions.ron]]
@@ -784,7 +751,7 @@ version = "1.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde]]
-version = "1.0.228"
+version = "1.0.229"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde-untagged]]
@@ -792,15 +759,15 @@ version = "0.1.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_core]]
-version = "1.0.228"
+version = "1.0.229"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_derive]]
-version = "1.0.228"
+version = "1.0.229"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_json]]
-version = "1.0.150"
+version = "1.0.151"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_spanned]]
@@ -816,11 +783,11 @@ version = "0.7.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.serial_test]]
-version = "3.5.0"
+version = "4.0.1"
 criteria = "safe-to-run"
 
 [[exemptions.serial_test_derive]]
-version = "3.5.0"
+version = "4.0.1"
 criteria = "safe-to-run"
 
 [[exemptions.shlex]]
@@ -859,6 +826,10 @@ criteria = "safe-to-deploy"
 version = "2.0.118"
 criteria = "safe-to-deploy"
 
+[[exemptions.syn]]
+version = "3.0.3"
+criteria = "safe-to-deploy"
+
 [[exemptions.sync_wrapper]]
 version = "1.0.2"
 criteria = "safe-to-deploy"
@@ -868,11 +839,11 @@ version = "0.4.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.thiserror]]
-version = "2.0.18"
+version = "2.0.19"
 criteria = "safe-to-deploy"
 
 [[exemptions.thiserror-impl]]
-version = "2.0.18"
+version = "2.0.19"
 criteria = "safe-to-deploy"
 
 [[exemptions.time]]
@@ -900,7 +871,7 @@ version = "1.11.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio]]
-version = "1.52.3"
+version = "1.53.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-macros]]
@@ -928,7 +899,7 @@ version = "0.8.23"
 criteria = "safe-to-deploy"
 
 [[exemptions.toml]]
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.toml_datetime]]
@@ -952,7 +923,7 @@ version = "0.1.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.toml_writer]]
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tonic]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -98,6 +98,18 @@ criteria = "safe-to-deploy"
 version = "1.1.2"
 notes = "Contains `unsafe` code but it's well-documented and scoped to what it's intended to be doing. Otherwise a well-focused and straightforward crate."
 
+[[audits.bytecode-alliance.audits.crossbeam-epoch]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.15 -> 0.9.18"
+notes = "Nontrivial update but mostly around dependencies and how `unsafe` code is managed. Everything looks the same shape as before."
+
+[[audits.bytecode-alliance.audits.crossbeam-epoch]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.18 -> 0.9.20"
+notes = "Minor updates, nothing out of place."
+
 [[audits.bytecode-alliance.audits.foldhash]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -384,6 +396,18 @@ aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust
 who = "Daniel Verkamp <dverkamp@chromium.org>"
 criteria = "safe-to-run"
 version = "0.2.2"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.crossbeam-epoch]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.9.14"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.crossbeam-epoch]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+delta = "0.9.14 -> 0.9.15"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
 [[audits.google.audits.difflib]]


### PR DESCRIPTION
## What

Adds a tool that tails the last N parseable records across every file matching a glob pattern, newest last, with an optional minimum level filter (extends the single-file tail_log). cargo test + clippy -D warnings clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)