### PR TITLE
chore(deps): consolidate dependency updates for v0.0.13

### DIFF
--- a/.github/workflows/bench-publish.yml
+++ b/.github/workflows/bench-publish.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@v2.85.5
         with:
           tool: cargo-criterion
 

--- a/.github/workflows/cargo-vet.yml
+++ b/.github/workflows/cargo-vet.yml
@@ -36,7 +36,7 @@ jobs:
       # the `trusted-publisher` field (cargo-vet 0.10+), which
       # earlier cargo-vet releases reject with "missing field
       # `user-id`".
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@v2.85.5
         with:
           tool: cargo-vet@0.10.2
 

--- a/.github/workflows/fuzz-smoke.yml
+++ b/.github/workflows/fuzz-smoke.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           components: rust-src
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@v2.85.5
         with:
           tool: cargo-fuzz
 

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@v2.85.5
         with:
           tool: cargo-semver-checks
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ dependencies = [
  "serde-untagged",
  "serde_core",
  "serde_json",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "winnow 1.0.3",
  "yaml-rust2",
 ]
@@ -901,9 +901,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2021,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "rlg"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "config",
  "criterion",
@@ -2049,7 +2049,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-test",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-cli"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2073,7 +2073,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-ebpf"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "criterion",
  "libc",
@@ -2083,7 +2083,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-mcp"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2097,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-otlp"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "criterion",
  "prost",
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-redact"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "criterion",
  "regex",
@@ -2124,7 +2124,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-report"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2140,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-test"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "criterion",
  "parking_lot",
@@ -2150,7 +2150,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-tower"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "criterion",
  "http",
@@ -2165,7 +2165,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-wasm"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "criterion",
  "rlg",
@@ -2758,9 +2758,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -2805,9 +2805,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow 1.0.3",
 ]

--- a/crates/rlg-cli/Cargo.toml
+++ b/crates/rlg-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-cli"
-version = "0.0.12"
+version = "0.0.13"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -46,7 +46,7 @@ name = "filter_by_attribute"
 path = "examples/filter_by_attribute.rs"
 
 [dependencies]
-rlg = { version = "0.0.12", path = "../rlg" }
+rlg = { version = "0.0.13", path = "../rlg" }
 clap = { version = "4.6", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"

--- a/crates/rlg-ebpf/Cargo.toml
+++ b/crates/rlg-ebpf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-ebpf"
-version = "0.0.12"
+version = "0.0.13"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -43,7 +43,7 @@ name = "chain"
 path = "examples/chain.rs"
 
 [dependencies]
-rlg = { version = "0.0.12", path = "../rlg" }
+rlg = { version = "0.0.13", path = "../rlg" }
 serde_json = "1.0"
 
 # Unix pid/tid/uid via libc. Cross-Unix; Windows implementation

--- a/crates/rlg-mcp/Cargo.toml
+++ b/crates/rlg-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-mcp"
-version = "0.0.12"
+version = "0.0.13"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -47,8 +47,8 @@ name = "dispatch"
 path = "examples/dispatch.rs"
 
 [dependencies]
-rlg = { version = "0.0.12", path = "../rlg" }
-rlg-cli = { version = "0.0.12", path = "../rlg-cli" }
+rlg = { version = "0.0.13", path = "../rlg" }
+rlg-cli = { version = "0.0.13", path = "../rlg-cli" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"

--- a/crates/rlg-otlp/Cargo.toml
+++ b/crates/rlg-otlp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-otlp"
-version = "0.0.12"
+version = "0.0.13"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -57,7 +57,7 @@ harness = false
 path = "benches/serialise.rs"
 
 [dependencies]
-rlg = { version = "0.0.12", path = "../rlg" }
+rlg = { version = "0.0.13", path = "../rlg" }
 ureq = { version = "3.1", features = ["json"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/rlg-redact/Cargo.toml
+++ b/crates/rlg-redact/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-redact"
-version = "0.0.12"
+version = "0.0.13"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -44,7 +44,7 @@ harness = false
 path = "benches/scrub.rs"
 
 [dependencies]
-rlg = { version = "0.0.12", path = "../rlg" }
+rlg = { version = "0.0.13", path = "../rlg" }
 regex = "1.12"
 serde_json = "1.0"
 

--- a/crates/rlg-report/Cargo.toml
+++ b/crates/rlg-report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-report"
-version = "0.0.12"
+version = "0.0.13"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -43,8 +43,8 @@ harness = false
 path = "benches/aggregate.rs"
 
 [dependencies]
-rlg = { version = "0.0.12", path = "../rlg" }
-rlg-cli = { version = "0.0.12", path = "../rlg-cli" }
+rlg = { version = "0.0.13", path = "../rlg" }
+rlg-cli = { version = "0.0.13", path = "../rlg-cli" }
 clap = { version = "4.6", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/rlg-test/Cargo.toml
+++ b/crates/rlg-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-test"
-version = "0.0.12"
+version = "0.0.13"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -39,7 +39,7 @@ harness = false
 path = "benches/capture.rs"
 
 [dependencies]
-rlg = { version = "0.0.12", path = "../rlg" }
+rlg = { version = "0.0.13", path = "../rlg" }
 parking_lot = "0.12"
 serde_json = "1.0"
 

--- a/crates/rlg-tower/Cargo.toml
+++ b/crates/rlg-tower/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-tower"
-version = "0.0.12"
+version = "0.0.13"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -40,7 +40,7 @@ harness = false
 path = "benches/layer.rs"
 
 [dependencies]
-rlg = { version = "0.0.12", path = "../rlg" }
+rlg = { version = "0.0.13", path = "../rlg" }
 tower = { version = "0.5", default-features = false }
 tower-layer = "0.3"
 tower-service = "0.3"

--- a/crates/rlg-wasm/Cargo.toml
+++ b/crates/rlg-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-wasm"
-version = "0.0.12"
+version = "0.0.13"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -44,7 +44,7 @@ harness = false
 path = "benches/build.rs"
 
 [dependencies]
-rlg = { version = "0.0.12", path = "../rlg" }
+rlg = { version = "0.0.13", path = "../rlg" }
 serde_json = "1.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/rlg/Cargo.toml
+++ b/crates/rlg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg"
-version = "0.0.12"
+version = "0.0.13"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -327,7 +327,7 @@ version = "0.4.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.http]]
-version = "1.4.2"
+version = "1.5.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.http-body]]
@@ -899,7 +899,7 @@ version = "0.8.23"
 criteria = "safe-to-deploy"
 
 [[exemptions.toml]]
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.toml_datetime]]
@@ -915,7 +915,7 @@ version = "0.22.27"
 criteria = "safe-to-deploy"
 
 [[exemptions.toml_parser]]
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.toml_write]]


### PR DESCRIPTION
Consolidates the open Dependabot PRs into a single release branch and bumps the version to `0.0.13`.

### Superseded updates

| PR | Update |
|----|--------|
| #180 | chore(deps): Bump the minor-and-patch group with 2 updates |
| #179 | chore(deps): Bump taiki-e/install-action from 2 to 2.85.5 |

### Verification

- `cargo fmt --all --check` clean ✅
- `cargo clippy --workspace --all-targets -- -D warnings` clean ✅
- `cargo test --workspace` — all tests pass, 0 failures ✅

Bumps every workspace crate 0.0.12 → 0.0.13, including the intra-workspace `rlg = { version = ... }` pins, and refreshes `Cargo.lock`.
