### PR TITLE
chore(deps): consolidate dependency updates for v0.0.14

### DIFF
--- a/.github/workflows/bench-publish.yml
+++ b/.github/workflows/bench-publish.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: taiki-e/install-action@v2.85.5
+      - uses: taiki-e/install-action@v2.85.10
         with:
           tool: cargo-criterion
 

--- a/.github/workflows/cargo-vet.yml
+++ b/.github/workflows/cargo-vet.yml
@@ -36,7 +36,7 @@ jobs:
       # the `trusted-publisher` field (cargo-vet 0.10+), which
       # earlier cargo-vet releases reject with "missing field
       # `user-id`".
-      - uses: taiki-e/install-action@v2.85.5
+      - uses: taiki-e/install-action@v2.85.10
         with:
           tool: cargo-vet@0.10.2
 

--- a/.github/workflows/fuzz-smoke.yml
+++ b/.github/workflows/fuzz-smoke.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           components: rust-src
 
-      - uses: taiki-e/install-action@v2.85.5
+      - uses: taiki-e/install-action@v2.85.10
         with:
           tool: cargo-fuzz
 

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: taiki-e/install-action@v2.85.5
+      - uses: taiki-e/install-action@v2.85.10
         with:
           tool: cargo-semver-checks
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -302,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2021,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "rlg"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "config",
  "criterion",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-cli"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2073,7 +2073,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-ebpf"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "criterion",
  "libc",
@@ -2083,7 +2083,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-mcp"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2097,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-otlp"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "criterion",
  "prost",
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-redact"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "criterion",
  "regex",
@@ -2124,7 +2124,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-report"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2140,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-test"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "criterion",
  "parking_lot",
@@ -2150,7 +2150,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-tower"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "criterion",
  "http",
@@ -2165,7 +2165,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-wasm"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "criterion",
  "rlg",

--- a/crates/rlg-cli/Cargo.toml
+++ b/crates/rlg-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-cli"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -46,7 +46,7 @@ name = "filter_by_attribute"
 path = "examples/filter_by_attribute.rs"
 
 [dependencies]
-rlg = { version = "0.0.13", path = "../rlg" }
+rlg = { version = "0.0.14", path = "../rlg" }
 clap = { version = "4.6", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"

--- a/crates/rlg-ebpf/Cargo.toml
+++ b/crates/rlg-ebpf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-ebpf"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -43,7 +43,7 @@ name = "chain"
 path = "examples/chain.rs"
 
 [dependencies]
-rlg = { version = "0.0.13", path = "../rlg" }
+rlg = { version = "0.0.14", path = "../rlg" }
 serde_json = "1.0"
 
 # Unix pid/tid/uid via libc. Cross-Unix; Windows implementation

--- a/crates/rlg-mcp/Cargo.toml
+++ b/crates/rlg-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-mcp"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -47,8 +47,8 @@ name = "dispatch"
 path = "examples/dispatch.rs"
 
 [dependencies]
-rlg = { version = "0.0.13", path = "../rlg" }
-rlg-cli = { version = "0.0.13", path = "../rlg-cli" }
+rlg = { version = "0.0.14", path = "../rlg" }
+rlg-cli = { version = "0.0.14", path = "../rlg-cli" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"

--- a/crates/rlg-otlp/Cargo.toml
+++ b/crates/rlg-otlp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-otlp"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -57,7 +57,7 @@ harness = false
 path = "benches/serialise.rs"
 
 [dependencies]
-rlg = { version = "0.0.13", path = "../rlg" }
+rlg = { version = "0.0.14", path = "../rlg" }
 ureq = { version = "3.1", features = ["json"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/rlg-redact/Cargo.toml
+++ b/crates/rlg-redact/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-redact"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -44,7 +44,7 @@ harness = false
 path = "benches/scrub.rs"
 
 [dependencies]
-rlg = { version = "0.0.13", path = "../rlg" }
+rlg = { version = "0.0.14", path = "../rlg" }
 regex = "1.12"
 serde_json = "1.0"
 

--- a/crates/rlg-report/Cargo.toml
+++ b/crates/rlg-report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-report"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -43,8 +43,8 @@ harness = false
 path = "benches/aggregate.rs"
 
 [dependencies]
-rlg = { version = "0.0.13", path = "../rlg" }
-rlg-cli = { version = "0.0.13", path = "../rlg-cli" }
+rlg = { version = "0.0.14", path = "../rlg" }
+rlg-cli = { version = "0.0.14", path = "../rlg-cli" }
 clap = { version = "4.6", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/rlg-test/Cargo.toml
+++ b/crates/rlg-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-test"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -39,7 +39,7 @@ harness = false
 path = "benches/capture.rs"
 
 [dependencies]
-rlg = { version = "0.0.13", path = "../rlg" }
+rlg = { version = "0.0.14", path = "../rlg" }
 parking_lot = "0.12"
 serde_json = "1.0"
 

--- a/crates/rlg-tower/Cargo.toml
+++ b/crates/rlg-tower/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-tower"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -40,7 +40,7 @@ harness = false
 path = "benches/layer.rs"
 
 [dependencies]
-rlg = { version = "0.0.13", path = "../rlg" }
+rlg = { version = "0.0.14", path = "../rlg" }
 tower = { version = "0.5", default-features = false }
 tower-layer = "0.3"
 tower-service = "0.3"

--- a/crates/rlg-wasm/Cargo.toml
+++ b/crates/rlg-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-wasm"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -44,7 +44,7 @@ harness = false
 path = "benches/build.rs"
 
 [dependencies]
-rlg = { version = "0.0.13", path = "../rlg" }
+rlg = { version = "0.0.14", path = "../rlg" }
 serde_json = "1.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/rlg/Cargo.toml
+++ b/crates/rlg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -131,11 +131,11 @@ version = "0.10.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap]]
-version = "4.6.4"
+version = "4.6.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_builder]]
-version = "4.6.2"
+version = "4.6.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_derive]]


### PR DESCRIPTION
Supersedes #182, #183.

- `clap` 4.6.4 -> 4.6.6 in the minor-and-patch group (#183)
- `taiki-e/install-action` v2.85.5 -> v2.85.10 (#182)
- version 0.0.13 -> 0.0.14 across the 10 workspace crates

`feat/v0.0.11` is `ahead=0` — merged long ago — so it does not suppress the bump.

### install-action appears in four workflows, not two

#182 bumped two call sites. The pin is also used by `cargo-vet.yml` and `semver-checks.yml`, so taking the PR as-is would have left two workflows on v2.85.5. All four now move together.

### Version bump details

The 10 crates are versioned in lockstep with no `[workspace.package]` inheritance, so each manifest carries its own. Inter-crate path dependencies pin the version too — `rlg-cli`, `rlg-mcp`, `rlg-ebpf` and others declare `rlg = { version = "0.0.13", path = ... }` — so those move with them or the workspace stops resolving.

`xtask` stays at 0.0.0: internal task runner, excluded from release. The match was anchored so `version_check = "0.9.5"` in `crates/rlg/Cargo.toml` — a dependency, not a version — was not caught.

`Cargo.lock` came from #183 for the clap bump, then had its 10 workspace entries synced to 0.0.14. Bumping manifests without the lock fails every job that passes `--locked`.

### Verification

- `cargo check --locked --workspace`: exit 0
- `cargo test --workspace`: **665 passed, 0 failed**