### PR TITLE
ci(release): publish to crates.io via trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,8 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      # Mints the OIDC token crates.io exchanges for a publish token.
+      id-token: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -98,9 +100,18 @@ jobs:
       #   ├── rlg-test
       #   ├── rlg-tower
       #   └── rlg-wasm
+      # Trusted publishing: swaps this job's GitHub OIDC identity for a
+      # temporary crates.io token, revoked by the action's post step when
+      # the job ends. The config is per crate, so every crate this step
+      # walks needs its own trusted publisher on crates.io -- all ten of
+      # them, each pointing at this repository and release.yml.
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
       - name: Publish workspace (idempotent, dependency-ordered)
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"


### PR DESCRIPTION
Replaces the stored crates.io token with an OIDC exchange. crates.io
issues a short-lived token and the auth action's post step revokes it
when the job ends. Nothing is stored, so there is nothing to rotate and
nothing to leak.

The publish job gains `id-token: write`, and the registry token now
comes from the auth action's output rather than repository secrets.

Trusted publishing is configured **per crate**, and this workflow
publishes 10. Every one needs its own trusted publisher on
crates.io: repository owner sebastienrousseau, workflow release.yml,
no environment. Releases here are tag-triggered, so merging ahead of that
configuration changes nothing until the next tag is pushed.

actionlint reports no new findings.


Assisted-by: Claude:claude-opus-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)