### PR TITLE
docs: drop redundant explicit link targets

### DIFF
--- a/crates/rlg/src/engine.rs
+++ b/crates/rlg/src/engine.rs
@@ -9,7 +9,7 @@
 //! [`LogEvent`][crate::engine::LogEvent]s via
 //! [`LockFreeEngine::ingest()`][crate::engine::LockFreeEngine::ingest]
 //! using only atomic operations. A dedicated background thread drains events
-//! in batches of 64 and writes them through [`PlatformSink`](crate::sink::PlatformSink).
+//! in batches of 64 and writes them through [`crate::sink::PlatformSink`].
 //!
 //! **The Mutex is never locked on the hot path.** It exists solely for
 //! `shutdown()` to join the flusher thread.

--- a/crates/rlg/src/macros.rs
+++ b/crates/rlg/src/macros.rs
@@ -5,7 +5,7 @@
 
 //! Convenience macros for span tracking, latency profiling, and MCP notifications.
 //!
-//! All macros dispatch through the lock-free [`ENGINE`](crate::engine::ENGINE).
+//! All macros dispatch through the lock-free [`crate::engine::ENGINE`].
 
 /// Execute a block within an OTLP-tagged span.
 ///

--- a/crates/rlg/src/sink.rs
+++ b/crates/rlg/src/sink.rs
@@ -126,7 +126,7 @@ mod syslog_ffi {
 }
 
 impl PlatformSink {
-    /// Build a sink from the given [`Config`](crate::config::Config).
+    /// Build a sink from the given [`crate::config::Config`].
     ///
     /// Inspects `logging_destinations` in order:
     /// - `File(path)` → open for append


### PR DESCRIPTION
The GitHub Pages job builds workspace docs with
`RUSTDOCFLAGS="--cfg docsrs -D warnings"`, and
rustdoc::redundant_explicit_links has been failing it on main. Three
intra-doc links spell out a path whose final segment is already the
link label, so rustdoc resolves the label to the same item:

    [`PlatformSink`](crate::sink::PlatformSink)
    [`ENGINE`](crate::engine::ENGINE)
    [`Config`](crate::config::Config)

Each becomes a plain intra-doc link on the full path, which renders the
same target without the duplication.

The diagnostic carries no source span, which is what made this awkward
to locate from the CI log alone.

Verified with the workflow's exact command --
`RUSTDOCFLAGS="--cfg docsrs -D warnings" cargo doc --workspace
--all-features --no-deps` on nightly, which is the toolchain pages.yml
installs. Building on stable instead reports a misleading E0554 for
`feature(doc_cfg)`, since `--cfg docsrs` turns on an unstable feature.


Assisted-by: Claude:claude-opus-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)