### PR TITLE
fix: use the shared portable counter instead of AtomicU64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -88,7 +88,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -647,14 +647,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "euxis-commons"
-version = "0.0.2"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc1cf9c4720703ea04d9eb4a191ac8e43b597805742e102fb7eaa4d9c3f5b27"
+checksum = "b4a42a5a820a2fa5cc80776ac24cfcd22d2a5d906f7daa4c33c5fcf56b73053a"
 dependencies = [
  "serde",
  "thiserror",
@@ -1446,7 +1446,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1827,7 +1827,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2225,7 +2225,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2453,7 +2453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2547,7 +2547,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2557,7 +2557,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3248,7 +3248,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/rlg/Cargo.toml
+++ b/crates/rlg/Cargo.toml
@@ -71,7 +71,7 @@ required-features = ["tokio"]
 config = "0.15.22"
 crossbeam-queue = "0.3.12"
 envy = "0.4.2"
-euxis-commons = { version = "0.0.2", default-features = false, features = ["error", "config", "validation", "retry", "id", "time", "env"], package = "euxis-commons" }
+euxis-commons = { version = "0.0.4", default-features = false, features = ["error", "config", "validation", "retry", "id", "time", "env", "counter"], package = "euxis-commons" }
 hostname = "0.4.2"
 itoa = "1.0.18"
 log = "0.4.30"

--- a/crates/rlg/src/log.rs
+++ b/crates/rlg/src/log.rs
@@ -5,15 +5,16 @@
 
 use crate::datetime;
 use crate::{LogFormat, LogLevel};
+use euxis_commons::counter::Counter;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::LazyLock;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::Ordering;
 
 /// Monotonic session ID counter. Incremented atomically per `build()` call.
-static SESSION_COUNTER: AtomicU64 = AtomicU64::new(1);
+static SESSION_COUNTER: Counter = Counter::new(1);
 
 /// Hostname, resolved once and cached for the process lifetime.
 static CACHED_HOSTNAME: LazyLock<String> =

--- a/crates/rlg/src/tracing.rs
+++ b/crates/rlg/src/tracing.rs
@@ -10,7 +10,8 @@
 
 use crate::log::Log;
 use crate::log_level::LogLevel;
-use std::sync::atomic::{AtomicU64, Ordering};
+use euxis_commons::counter::Counter;
+use std::sync::atomic::Ordering;
 use tracing_core::field::{Field, Visit};
 use tracing_core::{Event, Level, Metadata, Subscriber};
 
@@ -30,7 +31,7 @@ fn map_tracing_level(level: Level) -> LogLevel {
 }
 
 /// Monotonic span ID counter for unique span identification.
-static SPAN_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
+static SPAN_ID_COUNTER: Counter = Counter::new(1);
 
 /// A `tracing::Subscriber` that routes events to the `RLG` engine.
 #[derive(Debug, Default, Clone, Copy)]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -247,7 +247,7 @@ version = "0.3.14"
 criteria = "safe-to-deploy"
 
 [[exemptions.euxis-commons]]
-version = "0.0.2"
+version = "0.0.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.fastrand]]


### PR DESCRIPTION
Fixes the `powerpc-unknown-linux-gnu` build.

rlg fails on targets without 64-bit atomics:

```
error[E0432]: unresolved import `std::sync::atomic::AtomicU64`
 --> crates/rlg/src/tracing.rs:13
```

Two statics were affected — `SPAN_ID_COUNTER` in `tracing.rs` and `SESSION_COUNTER` in `log.rs` — both monotonic sequence numbers read through `fetch_add`.

`euxis-commons` hit exactly this and grew a cfg-gated `Counter`. Rather than write a third copy of the same fallback here, `counter` was made public in euxis-commons 0.0.4 and rlg uses it.

Note the import is `euxis_commons::counter::Counter`, not `commons::…` — rlg re-exports the crate as `commons` from its own root, which a module-level `use` does not resolve against.

`kani_proofs.rs` still names `AtomicU64`; it is `#[cfg(kani)]` and only compiles under `cargo kani` on x86-64, so it cannot affect the target matrix.

Verified against the published 0.0.4 with no local override: powerpc check passes with default features (the configuration xtasks builds), plus clippy -D warnings, fmt and the full test suite on the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)