### PR TITLE
ci(release): allow re-releasing an existing tag by dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,22 @@ on:
   push:
     tags:
       - "v*"
+  # Lets an existing tag be re-released without deleting and re-pushing
+  # it. A GitHub Actions incident once left a tag-triggered run wedged --
+  # reported queued, completed and running at once, refusing both cancel
+  # and rerun -- and the only recovery was moving the tag, which is how
+  # a release gets published from the wrong commit.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to release, e.g. v0.0.14"
+        required: true
+        type: string
 
 env:
+  # Single source of truth for the tag being released. On a dispatch
+  # github.ref_name is the branch the run started from, not the tag.
+  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: '0'
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
@@ -29,11 +43,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 1
           persist-credentials: false
       - name: Check tag matches every publishable crate
         run: |
-          TAG="${GITHUB_REF_NAME#v}"
+          TAG="${RELEASE_TAG#v}"
           for crate in \
               rlg \
               rlg-cli \
@@ -77,6 +92,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 1
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
@@ -114,7 +130,7 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           set -euo pipefail
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${RELEASE_TAG#v}"
 
           # publish_or_skip <crate> [sparse_index_sleep_seconds]
           #
@@ -168,13 +184,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Create release with auto-generated notes
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: ${{ inputs.tag || github.ref_name }}
           generate_release_notes: true
           draft: false
           prerelease: false
@@ -233,7 +250,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${GITHUB_REF_NAME}" \
+          gh release upload "${RELEASE_TAG}" \
             sbom.spdx.json \
             sbom.spdx.json.sig \
             sbom.spdx.json.crt \


### PR DESCRIPTION
Ports the fix made to euxis-commons after a GitHub Actions incident
left a tag-triggered release wedged: the API reported the run as queued
with zero jobs, refused `gh run cancel` with "cannot cancel a workflow
run that is completed", and refused `gh run rerun` with "this workflow
is already running". With `push` tags as the only trigger, the sole
recovery was deleting and re-pushing the tag, which is how a release
ends up published from the wrong commit.

`workflow_dispatch` now takes the tag as a required input.

This workflow reads the ref in seven places across three jobs, so the
port is larger than it was for commons:

- `RELEASE_TAG` is resolved once at workflow level as
  `inputs.tag || github.ref_name`, and the three shell sites use it
  instead of GITHUB_REF_NAME, which on a dispatch is the branch.
- All three checkouts pin `ref: inputs.tag || github.ref`, preserving
  each job's existing fetch-depth. Without this the publish job would
  package the default branch and upload it under the tag's version --
  a worse failure than the one being worked around, because it would
  succeed silently.
- `softprops/action-gh-release` takes the resolved tag rather than
  `github.ref_name`.

actionlint is clean.


Assisted-by: Claude:claude-opus-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)