### PR TITLE
chore(release): renumber to 0.0.12 and write the release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing tag to release, e.g. v0.0.14"
+        description: "Existing tag to release, e.g. v0.0.12"
         required: true
         type: string
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,76 @@ All notable changes to this project are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.12] — 2026-07-24
+## [0.0.12] — 2026-08-26
 
-(Nothing yet — `[v0.0.11]` is the cut.)
+The **portability and supply-chain** cut. Fixes a build failure on
+targets without 64-bit atomics, moves publishing to crates.io Trusted
+Publishing, and folds in eight weeks of dependency and MCP work.
+
+Workspace-lockstep versioning: all 10 publishable crates are at
+`0.0.12` (`rlg`, `rlg-cli`, `rlg-ebpf`, `rlg-mcp`, `rlg-otlp`,
+`rlg-redact`, `rlg-report`, `rlg-test`, `rlg-tower`, `rlg-wasm`).
+`xtask` stays at `0.0.0` per workspace convention.
+
+**A note on version numbering.** The manifests briefly carried `0.0.13`
+and `0.0.14` while dependency batches were consolidated under those
+names, but neither was ever tagged or published — crates.io went
+straight from `0.0.11` to here. Rather than publish two versions that
+predate the portability fix below and would be permanently broken on
+32-bit targets, the manifests were renumbered back to `0.0.12`, which
+is the version this CHANGELOG and the README already advertised. There
+is no `0.0.13` or `0.0.14`, and there never was one to install.
+
+### Fixed
+
+- **Builds on targets without 64-bit atomics.** `SPAN_ID_COUNTER` in
+  `tracing.rs` and `SESSION_COUNTER` in `log.rs` used `AtomicU64`,
+  which does not exist on `powerpc-unknown-linux-gnu` and similar
+  targets — the import failed outright with `E0432`. Both now use
+  `euxis_commons::counter::Counter`, which selects a lock-free or
+  mutex-backed implementation behind
+  `#[cfg(target_has_atomic = "64")]`. Verified with
+  `cargo check -p rlg --target powerpc-unknown-linux-gnu`.
+- **RUSTSEC-2026-0204** patched, alongside clippy 1.97 lints and TUI
+  test feature gates.
+- **`rustdoc::redundant_explicit_links`** failures that were breaking
+  the GitHub Pages documentation build.
+- **`publish-mcp`** no longer injects `packages[0].version` at publish
+  time.
+- **`docsrs` `doc(cfg)`** failure in the documentation build.
+
+### Changed
+
+- **Publishing uses crates.io Trusted Publishing.** Releases
+  authenticate over OIDC rather than a stored `CARGO_REGISTRY_TOKEN`,
+  so there is no long-lived registry credential in the repository. The
+  secret has been removed.
+- **Releases can be re-run without moving a tag.** The release
+  workflow accepts a `workflow_dispatch` with the tag to publish, after
+  a GitHub Actions incident left a tag-triggered run unrecoverable —
+  it reported as queued, completed and running at once and refused both
+  cancel and rerun. All three jobs pin their checkout to the supplied
+  tag, so a dispatch cannot package the default branch under a tag's
+  version.
+- **Dependabot** groups GitHub Actions updates into a single pull
+  request.
+
+### Added — MCP
+
+- **Prompts and resources** for MCP Trinity parity.
+- **`tail_logs_glob`** — a multi-file glob log tailer.
+- **`glama.json`**, tool titles, MCP annotations and usage guidance.
+- **Dockerfile** so Glama can build a release image.
+- **CNAME written into the Pages artifact**, so the custom
+  documentation domain survives each deploy.
+
+### Dependencies
+
+Eight weeks of consolidated updates, including `serial_test` 3.5 → 4.0,
+`actions/setup-node` 6 → 7, `actions/configure-pages` 5 → 6, several
+`minor-and-patch` group batches, and `euxis-commons` 0.0.2 → 0.0.4
+(which carries the portable counter above). cargo-vet exemptions were
+moved to match.
 
 ## [v0.0.11] - 2026-07-02
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "rlg"
-version = "0.0.14"
+version = "0.0.12"
 dependencies = [
  "config",
  "criterion",
@@ -2064,7 +2064,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-cli"
-version = "0.0.14"
+version = "0.0.12"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2079,7 +2079,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-ebpf"
-version = "0.0.14"
+version = "0.0.12"
 dependencies = [
  "criterion",
  "libc",
@@ -2089,7 +2089,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-mcp"
-version = "0.0.14"
+version = "0.0.12"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2103,7 +2103,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-otlp"
-version = "0.0.14"
+version = "0.0.12"
 dependencies = [
  "criterion",
  "prost",
@@ -2120,7 +2120,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-redact"
-version = "0.0.14"
+version = "0.0.12"
 dependencies = [
  "criterion",
  "regex",
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-report"
-version = "0.0.14"
+version = "0.0.12"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-test"
-version = "0.0.14"
+version = "0.0.12"
 dependencies = [
  "criterion",
  "parking_lot",
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-tower"
-version = "0.0.14"
+version = "0.0.12"
 dependencies = [
  "criterion",
  "http",
@@ -2171,7 +2171,7 @@ dependencies = [
 
 [[package]]
 name = "rlg-wasm"
-version = "0.0.14"
+version = "0.0.12"
 dependencies = [
  "criterion",
  "rlg",

--- a/crates/rlg-cli/Cargo.toml
+++ b/crates/rlg-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-cli"
-version = "0.0.14"
+version = "0.0.12"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -46,7 +46,7 @@ name = "filter_by_attribute"
 path = "examples/filter_by_attribute.rs"
 
 [dependencies]
-rlg = { version = "0.0.14", path = "../rlg" }
+rlg = { version = "0.0.12", path = "../rlg" }
 clap = { version = "4.6", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"

--- a/crates/rlg-ebpf/Cargo.toml
+++ b/crates/rlg-ebpf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-ebpf"
-version = "0.0.14"
+version = "0.0.12"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -43,7 +43,7 @@ name = "chain"
 path = "examples/chain.rs"
 
 [dependencies]
-rlg = { version = "0.0.14", path = "../rlg" }
+rlg = { version = "0.0.12", path = "../rlg" }
 serde_json = "1.0"
 
 # Unix pid/tid/uid via libc. Cross-Unix; Windows implementation

--- a/crates/rlg-mcp/Cargo.toml
+++ b/crates/rlg-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-mcp"
-version = "0.0.14"
+version = "0.0.12"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -47,8 +47,8 @@ name = "dispatch"
 path = "examples/dispatch.rs"
 
 [dependencies]
-rlg = { version = "0.0.14", path = "../rlg" }
-rlg-cli = { version = "0.0.14", path = "../rlg-cli" }
+rlg = { version = "0.0.12", path = "../rlg" }
+rlg-cli = { version = "0.0.12", path = "../rlg-cli" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"

--- a/crates/rlg-otlp/Cargo.toml
+++ b/crates/rlg-otlp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-otlp"
-version = "0.0.14"
+version = "0.0.12"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -57,7 +57,7 @@ harness = false
 path = "benches/serialise.rs"
 
 [dependencies]
-rlg = { version = "0.0.14", path = "../rlg" }
+rlg = { version = "0.0.12", path = "../rlg" }
 ureq = { version = "3.1", features = ["json"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/rlg-redact/Cargo.toml
+++ b/crates/rlg-redact/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-redact"
-version = "0.0.14"
+version = "0.0.12"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -44,7 +44,7 @@ harness = false
 path = "benches/scrub.rs"
 
 [dependencies]
-rlg = { version = "0.0.14", path = "../rlg" }
+rlg = { version = "0.0.12", path = "../rlg" }
 regex = "1.12"
 serde_json = "1.0"
 

--- a/crates/rlg-report/Cargo.toml
+++ b/crates/rlg-report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-report"
-version = "0.0.14"
+version = "0.0.12"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -43,8 +43,8 @@ harness = false
 path = "benches/aggregate.rs"
 
 [dependencies]
-rlg = { version = "0.0.14", path = "../rlg" }
-rlg-cli = { version = "0.0.14", path = "../rlg-cli" }
+rlg = { version = "0.0.12", path = "../rlg" }
+rlg-cli = { version = "0.0.12", path = "../rlg-cli" }
 clap = { version = "4.6", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/rlg-test/Cargo.toml
+++ b/crates/rlg-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-test"
-version = "0.0.14"
+version = "0.0.12"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -39,7 +39,7 @@ harness = false
 path = "benches/capture.rs"
 
 [dependencies]
-rlg = { version = "0.0.14", path = "../rlg" }
+rlg = { version = "0.0.12", path = "../rlg" }
 parking_lot = "0.12"
 serde_json = "1.0"
 

--- a/crates/rlg-tower/Cargo.toml
+++ b/crates/rlg-tower/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-tower"
-version = "0.0.14"
+version = "0.0.12"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -40,7 +40,7 @@ harness = false
 path = "benches/layer.rs"
 
 [dependencies]
-rlg = { version = "0.0.14", path = "../rlg" }
+rlg = { version = "0.0.12", path = "../rlg" }
 tower = { version = "0.5", default-features = false }
 tower-layer = "0.3"
 tower-service = "0.3"

--- a/crates/rlg-wasm/Cargo.toml
+++ b/crates/rlg-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg-wasm"
-version = "0.0.14"
+version = "0.0.12"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -44,7 +44,7 @@ harness = false
 path = "benches/build.rs"
 
 [dependencies]
-rlg = { version = "0.0.14", path = "../rlg" }
+rlg = { version = "0.0.12", path = "../rlg" }
 serde_json = "1.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/rlg/Cargo.toml
+++ b/crates/rlg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlg"
-version = "0.0.14"
+version = "0.0.12"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
crates.io is on 0.0.11. The manifests had drifted to 0.0.14 through two
dependency-consolidation batches named after versions that were never
tagged or published, leaving a two-version gap with nothing in it.

Filling that gap would have meant publishing 0.0.12 and 0.0.13 from
their historical commits. Both predate the AtomicU64 fix, so both would
be permanently broken on 32-bit targets — roughly twenty crate-versions
shipped knowingly broken to an immutable registry. Neither could
publish anyway: a tag push runs the workflow as it existed at that
commit, and those commits authenticate with the CARGO_REGISTRY_TOKEN
secret that Trusted Publishing replaced and which no longer exists.

Renumbering back to 0.0.12 gives crates.io a contiguous 0.0.11 ->
0.0.12 with no broken artifacts, and realigns the manifests with what
this CHANGELOG and the README already advertised.

- All 10 publishable crates and their inter-crate dependency
  requirements move 0.0.14 -> 0.0.12; xtask stays at 0.0.0 per
  workspace convention. Lockstep verified: the release workflow checks
  every publishable crate matches the tag.
- The 0.0.12 CHANGELOG entry replaces its "(Nothing yet)" placeholder
  with the eight weeks of work it actually covers, and records why
  0.0.13 and 0.0.14 do not exist.
- Cargo.lock regenerated; the dispatch input example now says v0.0.12.

Verified on rustc 1.98.0: fmt, clippy -D warnings, the full test suite,
cargo-audit (no advisories), cargo vet --locked (Vetting Succeeded),
`cargo check -p rlg --target powerpc-unknown-linux-gnu`, and
`cargo publish --dry-run -p rlg`, which packages rlg v0.0.12.


Assisted-by: Claude:claude-opus-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)